### PR TITLE
Feature/game/declarative

### DIFF
--- a/Pong/game/game.c
+++ b/Pong/game/game.c
@@ -11,7 +11,7 @@
 SDL_Renderer *renderer;
 SDL_Window *window;
 
-bool game_initializeGame(const char *title, const int w, const int h, void (*onGameInitialize)(void)) {
+bool game_initializeGame(const char *title, const int w, const int h, void (*onGameInitialize)(SDL_Renderer *renderer, SDL_Window *window)) {
     // Initialize core subsystems.
     int initialized = SDL_Init(SDL_INIT_VIDEO);
     if (initialized != 0) {
@@ -37,18 +37,18 @@ bool game_initializeGame(const char *title, const int w, const int h, void (*onG
     }
     
     if (onGameInitialize) {
-        onGameInitialize();
+        onGameInitialize(renderer, window);
     }
     
     return true;
 }
 
-void game_updateGame(const float timeElapsed, void (*onGameUpdate)(const float timeElapsed, SDL_Renderer *renderer)) {
+void game_updateGame(const float timeElapsed, void (*onGameUpdate)(const float timeElapsed, SDL_Renderer *renderer, SDL_Window *window)) {
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
     SDL_RenderClear(renderer);
     
     if (onGameUpdate) {
-        onGameUpdate(timeElapsed, renderer);
+        onGameUpdate(timeElapsed, renderer, window);
     }
     
     SDL_RenderPresent(renderer);

--- a/Pong/game/game.c
+++ b/Pong/game/game.c
@@ -43,12 +43,12 @@ bool game_initializeGame(const char *title, const int w, const int h, void (*onG
     return true;
 }
 
-void game_updateGame(const float timeElapsed, void (*onGameUpdate)(const float timeElapsed, SDL_Renderer *renderer, SDL_Window *window)) {
+void game_updateGame(const float timeElapsed, void (*onGameUpdate)(SDL_Renderer *renderer, SDL_Window *window, const float timeElapsed)) {
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
     SDL_RenderClear(renderer);
     
     if (onGameUpdate) {
-        onGameUpdate(timeElapsed, renderer, window);
+        onGameUpdate(renderer, window, timeElapsed);
     }
     
     SDL_RenderPresent(renderer);

--- a/Pong/game/game.h
+++ b/Pong/game/game.h
@@ -13,7 +13,7 @@
 #include <stdbool.h>
 
 extern bool game_initializeGame(const char *title, const int w, const int h, void (*onGameInitialize)(SDL_Renderer *renderer, SDL_Window *window));
-extern void game_updateGame(const float timeElapsed, void (*onGameUpdate)(const float timeElapsed, SDL_Renderer *renderer, SDL_Window *window));
+extern void game_updateGame(const float timeElapsed, void (*onGameUpdate)(SDL_Renderer *renderer, SDL_Window *window, const float timeElapsed));
 extern void game_shutdownGame(void);
 
 #endif /* game_h */

--- a/Pong/game/game.h
+++ b/Pong/game/game.h
@@ -12,8 +12,8 @@
 #include <SDL2/SDL.h>
 #include <stdbool.h>
 
-extern bool game_initializeGame(const char *title, const int w, const int h, void (*onGameInitialize)(void));
-extern void game_updateGame(const float timeElapsed, void (*onGameUpdate)(const float timeElapsed, SDL_Renderer *renderer));
+extern bool game_initializeGame(const char *title, const int w, const int h, void (*onGameInitialize)(SDL_Renderer *renderer, SDL_Window *window));
+extern void game_updateGame(const float timeElapsed, void (*onGameUpdate)(const float timeElapsed, SDL_Renderer *renderer, SDL_Window *window));
 extern void game_shutdownGame(void);
 
 #endif /* game_h */

--- a/Pong/main.c
+++ b/Pong/main.c
@@ -19,7 +19,7 @@ void main_handleGameInitialize(SDL_Renderer *renderer, SDL_Window *window) {
 }
 
 // TODO: Change ball position, paddle position, score value, etc.
-void main_handleGameUpdate(const float timeElapsed, SDL_Renderer *renderer, SDL_Window *window) {
+void main_handleGameUpdate(SDL_Renderer *renderer, SDL_Window *window, const float timeElapsed) {
 }
 
 int main(int argc, const char * argv[]) {

--- a/Pong/main.c
+++ b/Pong/main.c
@@ -15,11 +15,11 @@ const int WINDOW_WIDTH = 800;
 const int WINDOW_HEIGHT = 600;
 
 // TODO: Prepare ball, paddles, score, etc.
-void main_handleGameInitialize() {
+void main_handleGameInitialize(SDL_Renderer *renderer, SDL_Window *window) {
 }
 
 // TODO: Change ball position, paddle position, score value, etc.
-void main_handleGameUpdate(const float timeElapsed, SDL_Renderer *renderer) {
+void main_handleGameUpdate(const float timeElapsed, SDL_Renderer *renderer, SDL_Window *window) {
 }
 
 int main(int argc, const char * argv[]) {


### PR DESCRIPTION
I'd rather the consumers not need to decide how to retrieve the `renderer` and `window` singletons during `onGameInitialize` and `onGameUpdate` handlers. By doing this, I can avoid having to add even more API methods than I'm comfortable with.